### PR TITLE
New logo proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LuaCATS for Panic PlaydateSDK
 
-<img width="359" alt="AI Generated Image of cat holding a game controller" src="https://github.com/notpeter/playdate-luacats/assets/145113/4be26c10-42b2-4139-a926-31fffcf97f59">
+<img width="429" alt="playdate-LuaCATS logo" src="https://github.com/user-attachments/assets/cd94b9b4-b65a-4033-9bd8-179660fad527" />
 
 ## Unofficial Definitions for the Panic Playdate Lua SDK.
 


### PR DESCRIPTION
The new pixel-art logo incorporates the Lua logo, a cat, and the Playdate in the Playdate's iconic LCD colour scheme

<img width="858" height="840" alt="image" src="https://github.com/user-attachments/assets/895e3d11-677b-4f89-bf08-c136208c7555" />
