### PR TITLE
Fixed adding addWallSprites return type

### DIFF
--- a/library/stub.lua
+++ b/library/stub.lua
@@ -6171,7 +6171,7 @@ function playdate.graphics.sprite.addSprite(sprite) end
 ---@param emptyIDs integer[]
 ---@param xOffset? integer
 ---@param yOffset? integer
----@return nil
+---@return _Sprite[]
 function playdate.graphics.sprite.addWallSprites(tilemap, emptyIDs, xOffset, yOffset) end
 
 --- Returns an array of array-style tables, each containing two sprites that have overlapping


### PR DESCRIPTION
The `playdate.graphics.sprite` stub was missing the correct return type for the function `addWallSprites`. As per the documentation: (https://sdk.play.date/3.0.0/Inside%20Playdate.html#f-graphics.sprite.addWallSprites)

> This convenience function automatically adds empty collision sprites necessary to restrict movement within a tilemap.
> 
> tilemap is a [playdate.graphics.tilemap](https://sdk.play.date/3.0.0/Inside%20Playdate.html#C-graphics.tilemap).
> 
> emptyIDs is an array of tile IDs that should be considered "passable" — in other words, not walls. Tiles with default IDs of 0 are treated as passable by default, so you do not need to include 0 in the array.
> 
> xOffset, yOffset optionally indicate the distance the new sprites should be offset from (0,0).
> 
> **Returns an array-style table of the newly created sprites.** (Emphasis added by me)
> 
> Calling this function is effectively a shortcut for calling [playdate.graphics.tilemap:getCollisionRects()](https://sdk.play.date/3.0.0/Inside%20Playdate.html#m-graphics.tilemap.getCollisionRects) and passing the resulting rects to [addEmptyCollisionSprite()](https://sdk.play.date/3.0.0/Inside%20Playdate.html#f-graphics.sprite.addEmptyCollisionSprite).

Indeed I have been using this function with the array-of-sprites return type for a while without any issues. Only now that I looked through my linter warnings have I found this mismatch.

The PR is a simple correction on the return type of this function.