### PR TITLE
Add "acceleratedChange" return type to getCrankChange

### DIFF
--- a/library/stub.lua
+++ b/library/stub.lua
@@ -3436,7 +3436,8 @@ function playdate.getButtonState() end
 --- local change, acceleratedChange = playdate.getCrankChange()
 --- ```
 --- [Inside Playdate: playdate.getCrankChange](https://sdk.play.date/Inside%20Playdate.html#f-getCrankChange)
----@return number
+---@return number change
+---@return number acceleratedChange
 function playdate.getCrankChange() end
 
 --- Returns the absolute position of the crank (in degrees). Zero is pointing straight up parallel


### PR DESCRIPTION
Hi! Noticed that the getCrankChange function was missing the second acceleratedChange return type. Seems like you have your own backend process to generate the docs, so feel free to just toss this PR and make the fix on your own, but just wanted to bring it up. Thanks!

Thanks! https://sdk.play.date/3.0.1/Inside%20Playdate.html#f-getCrankChange