### PR TITLE
Added correct return types for playdate.graphics.drawTextInRect and related functions

### DIFF
--- a/library/stub.lua
+++ b/library/stub.lua
@@ -4162,7 +4162,9 @@ function playdate.graphics.drawLocalizedTextAligned(text, x, y, alignment, langu
 ---@param alignment? integer
 ---@param font? _Font
 ---@param language? (integer|string)
----@return nil
+---@return number width
+---@return number height
+---@return boolean textWasTruncated
 function playdate.graphics.drawLocalizedTextInRect(text, rect, leadingAdjustment, truncationString, alignment, font, language) end
 
 --- You must import *CoreLibs/graphics* to use these functions.
@@ -4180,7 +4182,9 @@ function playdate.graphics.drawLocalizedTextInRect(text, rect, leadingAdjustment
 ---@param alignment? integer
 ---@param font? playdate.graphics.font
 ---@param language? (integer|string)
----@return nil
+---@return number width
+---@return number height
+---@return boolean textWasTruncated
 function playdate.graphics.drawLocalizedTextInRect(text, x, y, width, height, leadingAdjustment, truncationString, alignment, font, language) end
 
 --- Draw a single pixel in the current color at (*x*, *y*).
@@ -4484,7 +4488,9 @@ function playdate.graphics.drawTextAligned(text, x, y, alignment, leadingAdjustm
 ---@param truncationString? string
 ---@param alignment? integer
 ---@param font? _Font
----@return nil
+---@return number width
+---@return number height
+---@return boolean textWasTruncated
 function playdate.graphics.drawTextInRect(text, rect, leadingAdjustment, truncationString, alignment, font) end
 
 --- You must import *CoreLibs/graphics* to use these functions.
@@ -4521,7 +4527,9 @@ function playdate.graphics.drawTextInRect(text, rect, leadingAdjustment, truncat
 ---@param truncationString? string
 ---@param alignment? integer
 ---@param font? playdate.graphics.font
----@return nil
+---@return number width
+---@return number height
+---@return boolean textWasTruncated
 function playdate.graphics.drawTextInRect(text, x, y, width, height, leadingAdjustment, truncationString, alignment, font) end
 
 --- Draws a triangle with vertices (*x1*, *y1*), (*x2*, *y2*), and (*x3*, *y3*).

--- a/library/stub.lua
+++ b/library/stub.lua
@@ -8685,7 +8685,7 @@ function playdate.setGCScaling(min, max) end
 --- To remove a previously-set menu image, pass `nil` for the *image* argument.
 ---
 --- [Inside Playdate: playdate.setMenuImage](https://sdk.play.date/Inside%20Playdate.html#f-setMenuImage)
----@param image _Image
+---@param image _Image?
 ---@param xOffset? integer
 ---@return nil
 function playdate.setMenuImage(image, xOffset) end
@@ -10085,7 +10085,7 @@ function playdate.sound.sequence.new(midi_path) end
 ---
 --- [Inside Playdate: playdate.sound.sequence:addTrack](https://sdk.play.date/Inside%20Playdate.html#m-sound.sequence.addTrack)
 ---@param track? _Track
----@return nil
+---@return _Track?
 function playdate.sound.sequence:addTrack(track) end
 
 --- Sends an allNotesOff() message to each track’s instrument.


### PR DESCRIPTION
Fixed the "return nil" with correct return types (width, height and boolean : textWasTruncated). According to the documentation:

```lua
--- Returns `*width*`, `*height*`, `*textWasTruncated*`
---
--- `*width*` and `*height*` indicate the size in pixels of the drawn text. These values may be
--- smaller than the width and height specified when calling the function.
---
--- `*textWasTruncated*` indicates if the text was truncated to fit within the specified rect.
```

Adjusted related functions: 

- `playdate.graphics.drawLocalizedTextInRect(text, rect, leadingAdjustment, truncationString, alignment, font, language)`
- `playdate.graphics.drawLocalizedTextInRect(text, x, y, width, height, leadingAdjustment, truncationString, alignment, font, language)`
- `playdate.graphics.drawTextInRect(text, rect, leadingAdjustment, truncationString, alignment, font)`
- `playdate.graphics.drawTextInRect(text, x, y, width, height, leadingAdjustment, truncationString, alignment, font)`
